### PR TITLE
Support gene features that have transcript/ncRNA subfeatures

### DIFF
--- a/lib/Bio/Graphics/Glyph/gene.pm
+++ b/lib/Bio/Graphics/Glyph/gene.pm
@@ -70,7 +70,7 @@ sub extra_arrow_length {
 sub pad_left {
   my $self = shift;
   my $type = $self->feature->primary_tag;
-  return 0 unless $type =~ /gene|mRNA|transcript/;
+  return 0 unless $type =~ /gene|rna|transcript/i;
   $self->SUPER::pad_left;
 }
 

--- a/lib/Bio/Graphics/Glyph/rainbow_gene.pm
+++ b/lib/Bio/Graphics/Glyph/rainbow_gene.pm
@@ -82,7 +82,7 @@ sub extra_arrow_length {
 sub pad_left {
   my $self = shift;
   my $type = $self->feature->primary_tag;
-  return 0 unless $type =~ /gene|mRNA/;
+  return 0 unless $type =~ /gene|rna|transcript/i;
   $self->SUPER::pad_left;
 }
 


### PR DESCRIPTION
The GFF for the [NCBI Glycine max Annotation Release 101](https://www.ncbi.nlm.nih.gov/genome/annotation_euk/Glycine_max/101/) (available at ftp://ftp.ncbi.nih.gov/genomes/Glycine_max/GFF/ref_V1.1_top_level.gff3.gz) contains gene features that have both mRNA and transcript subfeatures. In these cases, Bio::Graphics::Glyph::gene currently renders only the mRNA subfeatures:

![before_patch](https://cloud.githubusercontent.com/assets/1800812/2722559/79c7a094-c589-11e3-884e-ee994d0479a0.png)

The proposed commits causes transcript subfeatures to be rendered as well:

![after_patch](https://cloud.githubusercontent.com/assets/1800812/2722564/8102e1f2-c589-11e3-8d1b-6267c5df48d8.png)

Also, labels were previously displayed correctly only for mRNA & transcript subfeatures; they overlapped other *RNA subfeatures (e.g., ncRNA):

![gene_ncrna-before](https://cloud.githubusercontent.com/assets/1800812/2737205/e537d666-c677-11e3-9478-dfb9c254dd2d.png)

commit eebd2e4 fixes this:

![gene_ncrna-after](https://cloud.githubusercontent.com/assets/1800812/2737212/0ba86db0-c678-11e3-8320-05bc5aec8297.png)

Note that I made the changes to both Bio::Graphics::Glyph::gene and Bio::Graphics::Glyph::rainbow_gene, though I tested only the former.
