### PR TITLE
Add support for -implied_utrs and -adjust_exons to the gene glyph.

### DIFF
--- a/lib/Bio/Graphics/Glyph/gene.pm
+++ b/lib/Bio/Graphics/Glyph/gene.pm
@@ -148,6 +148,12 @@ sub maxdepth {
   return 2;
 }
 
+sub fixup_glyph {
+  my $self = shift;
+  return unless $self->level == 1;
+  $self->create_implied_utrs if $self->option('implied_utrs');
+  $self->adjust_exons        if $self->option('implied_utrs') || $self->option('adjust_exons');
+}
 
 sub _subfeat {
   my $class   = shift;
@@ -176,7 +182,11 @@ sub _subfeat {
     @subparts = $feature->get_SeqFeatures($class->option('sub_part'));
   }
   elsif ($feature->primary_tag =~ /^mRNA/i) {
-    @subparts = $feature->get_SeqFeatures(qw(CDS five_prime_UTR three_prime_UTR UTR));
+    if ($class->option('implied_utrs') || $class->option('adjust_exons')) {
+      @subparts = $feature->get_SeqFeatures(qw(CDS exon five_prime_UTR three_prime_UTR UTR));
+    } else {
+      @subparts = $feature->get_SeqFeatures(qw(CDS five_prime_UTR three_prime_UTR UTR));
+    }
   }
   else {
     @subparts = $feature->get_SeqFeatures('exon');
@@ -298,10 +308,6 @@ options:
   -decorate_introns
                  Draw strand with little arrows undef (false)
                  on the intron.
-
-The B<-adjust_exons> and B<-implied_utrs> options are inherited from
-processed_transcript, but are quietly ignored. Please use the
-processed_transcript glyph for this type of processing.
 
 =head1 BUGS
 


### PR DESCRIPTION
This patch adds support for the -implied_utrs option to the gene glyph, addressing issue https://github.com/GMOD/Bio-Graphics/issues/16. This change presumably adds support for -adjust_exons, though I haven't explicitly tested this.

An example of gene models from the Medicago truncatula 4.0 genome annotation rendered in GBrowse, before the patch:
![before](https://cloud.githubusercontent.com/assets/1800812/3193360/bcea653e-ecf1-11e3-8d49-57d34792f925.png)

After the patch:
![after](https://cloud.githubusercontent.com/assets/1800812/3193362/c53bfe32-ecf1-11e3-8432-2ff196324275.png)